### PR TITLE
Fixed fetching licenses without partner account

### DIFF
--- a/src/Shyim/PluginInstaller.php
+++ b/src/Shyim/PluginInstaller.php
@@ -319,10 +319,19 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
 
             self::$io->write(sprintf('[Installer] Found shop with domain "%s" in account', self::$shop['domain']), true);
 
-            self::$licenses = self::apiRequest('/licenses', 'GET', [
-                'partnerId' => $response['userId'],
+            $licenseParams = [
                 'shopId' => self::$shop['id']
-            ]);
+            ];
+
+            if ($partnerAccount) {
+                $licenseParams['partnerId'] = $response['userId'];
+            }
+
+            self::$licenses = self::apiRequest('/licenses', 'GET', $licenseParams);
+
+            if (isset(self::$licenses['success']) && !self::$licenses['success']) {
+                throw new \RuntimeException(sprintf('Fetching shop licenses failed with code "%s"!', self::$licenses['code']));
+            }
         }
     }
 


### PR DESCRIPTION
Fetching licenses without an partner account results in the following error:

> [Installer] Using $ACCOUNT_USER and $ACCOUNT_PASSWORD to login into the account
> [Installer] Successfully loggedin in the account
> [Installer] Found shop with domain "development-ltt-group.de" in account
> <pre>Array
> (
>     [success] => 
>     [code] => PluginLicensesException-8
> )
> </pre>

The reason is, that the license request gets the partnerId passed even if the account is no partner account.

This PR fixes it and adds an additional Exception.