### PR TITLE
silently fail on errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Example composer.json
 Set following environment variables
    * ACCOUNT_USER (Shopware User)
    * ACCOUNT_PASSWORD (Shopware Password)
+   * SW_STORE_PLUGIN_INSTALLER_SILENTFAIL (do not throw exceptions on errors / default: `false``)
 
 Install the composer plugin
 

--- a/src/Shyim/PluginInstaller.php
+++ b/src/Shyim/PluginInstaller.php
@@ -306,6 +306,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         if (isset($response['success']) && $response['success'] === false) {
             if (self::$silentFail) {
                 self::$io->write(sprintf('[Installer] Login to Account failed with code %s', $response['code']), true);
+                return false;
             } else {
                 throw new \RuntimeException(sprintf('[Installer] Login to Account failed with code %s', $response['code']));
             }
@@ -340,6 +341,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         if (count(self::$shop) === 0) {
             if (self::$silentFail) {
                 self::$io->write(sprintf('[Installer] Shop with given domain "%s" does not exist!', $domain), true);
+                return false;
             } else {
                 throw new \RuntimeException(sprintf('[Installer] Shop with given domain "%s" does not exist!', $domain));
             }
@@ -352,6 +354,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         if (isset(self::$shop['isWildcardShop'])) {
             if (self::$silentFail) {
                 self::$io->write(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']), true);
+                return false;
             } else {
                 throw new \RuntimeException(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']));
             }
@@ -369,6 +372,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
             if (isset(self::$licenses['success']) && !self::$licenses['success']) {
                 if (self::$silentFail) {
                     self::$io->write(sprintf('[Installer] Fetching shop licenses failed with code "%s"!', self::$licenses['code']), true);
+                    return false;
                 } else {
                     throw new \RuntimeException(sprintf('[Installer] Fetching shop licenses failed with code "%s"!', self::$licenses['code']));
                 }

--- a/src/Shyim/PluginInstaller.php
+++ b/src/Shyim/PluginInstaller.php
@@ -49,6 +49,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
     private static $licenses;
 
     /**
+     * @var boolean
+     */
+    private static $silentFail;
+
+    /**
      * @return array
      */
     public static function getSubscribedEvents()
@@ -94,6 +99,8 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
             (new Dotenv(getcwd()))->load();
         }
 
+        self::$silentFail = filter_var(Util::getenv('SW_STORE_PLUGIN_INSTALLER_SILENTFAIL', false), FILTER_VALIDATE_BOOLEAN);
+
         $extra = $e->getComposer()->getPackage()->getExtra();
 
         self::$extra = $extra;
@@ -133,7 +140,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         });
 
         if (empty($plugin)) {
-            throw new \RuntimeException(sprintf('Plugin with name "%s" is not available in your Account. Please buy the plugin first', $name));
+            if (self::$silentFail) {
+                self::$io->write(sprintf('[Installer] Plugin with name "%s" is not available in your Account. Please buy the plugin first', $name), true);
+            } else {
+                throw new \RuntimeException(sprintf('[Installer] Plugin with name "%s" is not available in your Account. Please buy the plugin first', $name));
+            }
         }
 
         $plugin = array_values($plugin)[0];
@@ -144,7 +155,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         $versions = array_column($plugin['plugin']['binaries'], 'version');
 
         if (!in_array($version, $versions)) {
-            throw new \RuntimeException(sprintf('Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $name, $version, implode(', ', array_reverse($versions))));
+            if (self::$silentFail) {
+                self::$io->write(sprintf('[Installer] Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $name, $version, implode(', ', array_reverse($versions))), true);
+            } else {
+                throw new \RuntimeException(sprintf('[Installer] Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $name, $version, implode(', ', array_reverse($versions))));
+            }
         }
 
         if ($path = LocalCache::getPlugin($name, $version)) {
@@ -289,7 +304,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         ]);
 
         if (isset($response['success']) && $response['success'] === false) {
-            throw new \RuntimeException(sprintf('Login to Account failed with code %s', $response['code']));
+            if (self::$silentFail) {
+                self::$io->write(sprintf('[Installer] Login to Account failed with code %s', $response['code']), true);
+            } else {
+                throw new \RuntimeException(sprintf('[Installer] Login to Account failed with code %s', $response['code']));
+            }
         }
 
         self::$io->write('[Installer] Successfully loggedin in the account', true);
@@ -319,7 +338,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         });
 
         if (count(self::$shop) === 0) {
-            throw new \RuntimeException(sprintf('Shop with given domain "%s" does not exist!', $domain));
+            if (self::$silentFail) {
+                self::$io->write(sprintf('[Installer] Shop with given domain "%s" does not exist!', $domain), true);
+            } else {
+                throw new \RuntimeException(sprintf('[Installer] Shop with given domain "%s" does not exist!', $domain));
+            }
         }
 
         self::$shop = array_values(self::$shop)[0];
@@ -327,7 +350,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         self::$io->write(sprintf('[Installer] Found shop with domain "%s" in account', self::$shop['domain']), true);
 
         if (isset(self::$shop['isWildcardShop'])) {
-            throw new \RuntimeException(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']));
+            if (self::$silentFail) {
+                self::$io->write(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']), true);
+            } else {
+                throw new \RuntimeException(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']));
+            }
         } else {
             $licenseParams = [
                 'shopId' => self::$shop['id']
@@ -340,7 +367,11 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
             self::$licenses = self::apiRequest('/licenses', 'GET', $licenseParams);
 
             if (isset(self::$licenses['success']) && !self::$licenses['success']) {
-                throw new \RuntimeException(sprintf('Fetching shop licenses failed with code "%s"!', self::$licenses['code']));
+                if (self::$silentFail) {
+                    self::$io->write(sprintf('[Installer] Fetching shop licenses failed with code "%s"!', self::$licenses['code']), true);
+                } else {
+                    throw new \RuntimeException(sprintf('[Installer] Fetching shop licenses failed with code "%s"!', self::$licenses['code']));
+                }
             }
         }
 

--- a/src/Shyim/PluginInstaller.php
+++ b/src/Shyim/PluginInstaller.php
@@ -140,7 +140,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         });
 
         if (empty($plugin)) {
-            $this->throwException(sprintf('[Installer] Plugin with name "%s" is not available in your Account. Please buy the plugin first', $name));
+            return $this->throwException(sprintf('[Installer] Plugin with name "%s" is not available in your Account. Please buy the plugin first', $name));
         }
 
         $plugin = array_values($plugin)[0];
@@ -151,7 +151,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         $versions = array_column($plugin['plugin']['binaries'], 'version');
 
         if (!in_array($version, $versions)) {
-            $this->throwException(sprintf('[Installer] Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $name, $version, implode(', ', array_reverse($versions))));
+            return $this->throwException(sprintf('[Installer] Plugin with name "%s" doesnt have the version "%s", Available versions are %s', $name, $version, implode(', ', array_reverse($versions))));
         }
 
         if ($path = LocalCache::getPlugin($name, $version)) {
@@ -296,7 +296,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         ]);
 
         if (isset($response['success']) && $response['success'] === false) {
-            $this->throwException(sprintf('[Installer] Login to Account failed with code %s', $response['code']));
+            return $this->throwException(sprintf('[Installer] Login to Account failed with code %s', $response['code']));
         }
 
         self::$io->write('[Installer] Successfully loggedin in the account', true);
@@ -326,7 +326,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         });
 
         if (count(self::$shop) === 0) {
-            $this->throwException(sprintf('[Installer] Shop with given domain "%s" does not exist!', $domain));
+            return $this->throwException(sprintf('[Installer] Shop with given domain "%s" does not exist!', $domain));
         }
 
         self::$shop = array_values(self::$shop)[0];
@@ -334,7 +334,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
         self::$io->write(sprintf('[Installer] Found shop with domain "%s" in account', self::$shop['domain']), true);
 
         if (isset(self::$shop['isWildcardShop'])) {
-            $this->throwException(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']));
+            return $this->throwException(sprintf('[Installer] Domain "%s" is wildcard. Wildcard domains are not supported', self::$shop['domain']));
         } else {
             $licenseParams = [
                 'shopId' => self::$shop['id']
@@ -347,7 +347,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
             self::$licenses = self::apiRequest('/licenses', 'GET', $licenseParams);
 
             if (isset(self::$licenses['success']) && !self::$licenses['success']) {
-                $this->throwException(sprintf('[Installer] Fetching shop licenses failed with code "%s"!', self::$licenses['code']));
+                return $this->throwException(sprintf('[Installer] Fetching shop licenses failed with code "%s"!', self::$licenses['code']));
             }
         }
 

--- a/src/Shyim/PluginInstaller.php
+++ b/src/Shyim/PluginInstaller.php
@@ -275,6 +275,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
     {
         $user = Util::getenv('ACCOUNT_USER');
         $password = Util::getenv('ACCOUNT_PASSWORD');
+        $shopUrl = Util::getenv('SHOP_URL_ALIAS') != '' ? Util::getenv('SHOP_URL_ALIAS') : Util::getenv('SHOP_URL');
 
         if (empty($user) || empty($password)) {
             self::$io->writeError('[Installer] The enviroment variable $ACCOUNT_USER and $ACCOUNT_PASSWORD are required!');
@@ -310,7 +311,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
             'userId' => $response['userId']
         ]);
 
-        $domain = parse_url(Util::getenv('SHOP_URL'), PHP_URL_HOST);
+        $domain = parse_url($shopUrl, PHP_URL_HOST);
 
         $shops = array_merge($shops, $clientshops, self::getWildcardDomains($response['userId']));
 

--- a/src/Shyim/PluginInstaller.php
+++ b/src/Shyim/PluginInstaller.php
@@ -275,7 +275,6 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
     {
         $user = Util::getenv('ACCOUNT_USER');
         $password = Util::getenv('ACCOUNT_PASSWORD');
-        $shopUrl = Util::getenv('SHOP_URL_ALIAS') != '' ? Util::getenv('SHOP_URL_ALIAS') : Util::getenv('SHOP_URL');
 
         if (empty($user) || empty($password)) {
             self::$io->writeError('[Installer] The enviroment variable $ACCOUNT_USER and $ACCOUNT_PASSWORD are required!');
@@ -311,7 +310,7 @@ class PluginInstaller implements PluginInterface, EventSubscriberInterface
             'userId' => $response['userId']
         ]);
 
-        $domain = parse_url($shopUrl, PHP_URL_HOST);
+        $domain = parse_url(Util::getenv('SHOP_URL'), PHP_URL_HOST);
 
         $shops = array_merge($shops, $clientshops, self::getWildcardDomains($response['userId']));
 


### PR DESCRIPTION
We use this plugin as part of our provisioning process with a composer-install method. In this scenario the first composer run is typically when the shop is not already registered in the shopware account. We still want to fully install the codebase (obviously without plugins from the account). To not break the whole process we need to circumvent exceptions.